### PR TITLE
"jj entropy"

### DIFF
--- a/jj/cmd.go
+++ b/jj/cmd.go
@@ -103,8 +103,8 @@ func CreateVersionCommand() *cobra.Command {
 }
 
 func CreateEntropycommand() *cobra.Command {
-	var rpc string
-	var N, samples int
+	var rpc, player string
+	var samples int
 
 	entropyCmd := &cobra.Command{
 		Use:   "entropy",
@@ -113,8 +113,8 @@ func CreateEntropycommand() *cobra.Command {
 			if rpc == "" {
 				return errors.New("--rpc/-r is required")
 			}
-			if N == 0 {
-				return errors.New("--base/-N is required")
+			if player == "" {
+				return errors.New("--player/-p is required")
 			}
 			if samples == 0 {
 				return errors.New("--samples/-s is required")
@@ -128,19 +128,16 @@ func CreateEntropycommand() *cobra.Command {
 				return blocksErr
 			}
 
-			entropy, entropyErr := entropy.EntropyModN(blocks, N)
-			if entropyErr != nil {
-				return entropyErr
-			}
+			itemEntropy, terrainEntropy, outcomeEntropy := entropy.Entropies(blocks, player)
 
-			cmd.Println(entropy)
+			cmd.Printf("Item entropy: %f\nTerrain entropy: %f\nOutcome entropy: %f\n", itemEntropy, terrainEntropy, outcomeEntropy)
 
 			return nil
 		},
 	}
 
 	entropyCmd.Flags().StringVarP(&rpc, "rpc", "r", "", "JSON-RPC API URL for the blockchain to sample from")
-	entropyCmd.Flags().IntVarP(&N, "base", "N", 0, "Entropy is calculated for blockhashes modulo this base")
+	entropyCmd.Flags().StringVarP(&player, "player", "p", "", "Player address")
 	entropyCmd.Flags().IntVarP(&samples, "samples", "s", 0, "Number of blocks to sample")
 
 	return entropyCmd

--- a/jj/entropy/analyze.go
+++ b/jj/entropy/analyze.go
@@ -4,43 +4,103 @@ import (
 	"errors"
 	"math"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var ErrParseBlockHash error = errors.New("could not parse block number")
 
-func EntropyModN(blocks []BlockResult, N int) (float64, error) {
-	index := make(map[string]bool)
-	reductionFrequencies := make(map[int64]int)
+func Entropies(blocks []BlockResult, player string) (float64, float64, float64) {
+	one := big.NewInt(1)
+	two := big.NewInt(2)
+	four := big.NewInt(4)
+	seven := big.NewInt(7)
+	twenty := big.NewInt(20)
+	onehundredeighteen := big.NewInt(118)
 
-	base := new(big.Int)
-	base.SetInt64(int64(N))
+	outcomeMask := new(big.Int)
+	outcomeMask.Exp(two, twenty, nil)
+	outcomeMask.Sub(outcomeMask, one)
+
+	terrainMask := new(big.Int)
+	terrainMask.Exp(two, onehundredeighteen, nil)
+	terrainMask.Sub(terrainMask, one)
+	terrainMask.Lsh(terrainMask, 20)
+
+	itemMask := new(big.Int)
+	itemMask.Set(terrainMask)
+	itemMask.Lsh(itemMask, 118)
+
+	index := make(map[string]bool)
+	itemReductionFrequencies := make(map[int64]int)
+	terrainReductionFrequencies := make(map[int64]int)
+	outcomeReductionFrequencies := make(map[int64]int)
+
 	for _, block := range blocks {
 		_, blockNumberProcessed := index[block.Number]
 		if !blockNumberProcessed {
 			index[block.Number] = true
 
+			blockhash := common.HexToHash(block.Hash)
+			address := common.HexToAddress(player)
+			data := append(blockhash.Bytes(), address.Bytes()...)
+
+			hashBytes := crypto.Keccak256(data)
+
 			value := new(big.Int)
-			_, ok := value.SetString(block.Hash, 0)
-			if !ok {
-				return 0, ErrParseBlockHash
+			value.SetBytes(hashBytes)
+
+			itemRNG := new(big.Int)
+			itemRNG.And(value, itemMask)
+			itemRNG.Rsh(itemRNG, 138)
+			itemRNG.Mod(itemRNG, four)
+			itemReduction := itemRNG.Int64()
+			_, itemReductionExists := itemReductionFrequencies[itemReduction]
+			if itemReductionExists {
+				itemReductionFrequencies[itemReduction] += 1
+			} else {
+				itemReductionFrequencies[itemReduction] = 1
 			}
 
-			reduction := value.Mod(value, base).Int64()
-
-			_, reductionExists := reductionFrequencies[reduction]
-			if reductionExists {
-				reductionFrequencies[reduction] += 1
+			terrainRNG := new(big.Int)
+			terrainRNG.And(value, terrainMask)
+			terrainRNG.Rsh(terrainRNG, 20)
+			terrainRNG.Mod(terrainRNG, seven)
+			terrainReduction := terrainRNG.Int64()
+			_, terrainReductionExists := terrainReductionFrequencies[terrainReduction]
+			if terrainReductionExists {
+				terrainReductionFrequencies[terrainReduction] += 1
 			} else {
-				reductionFrequencies[reduction] = 1
+				terrainReductionFrequencies[terrainReduction] = 1
+			}
+
+			outcomeRNG := new(big.Int)
+			outcomeRNG.And(value, outcomeMask)
+			outcomeRNG.Mod(outcomeRNG, four)
+			outcomeReduction := outcomeRNG.Int64()
+			_, outcomeReductionExists := outcomeReductionFrequencies[outcomeReduction]
+			if outcomeReductionExists {
+				outcomeReductionFrequencies[outcomeReduction] += 1
+			} else {
+				outcomeReductionFrequencies[outcomeReduction] = 1
 			}
 		}
 	}
 
-	var entropy float64 = 0
-	for _, frequency := range reductionFrequencies {
+	var itemEntropy, terrainEntropy, outcomeEntropy float64 = 0, 0, 0
+	for _, frequency := range itemReductionFrequencies {
 		p := float64(frequency) / float64(len(index))
-		entropy -= p * math.Log2(p)
+		itemEntropy -= p * math.Log2(p)
+	}
+	for _, frequency := range terrainReductionFrequencies {
+		p := float64(frequency) / float64(len(index))
+		terrainEntropy -= p * math.Log2(p)
+	}
+	for _, frequency := range outcomeReductionFrequencies {
+		p := float64(frequency) / float64(len(index))
+		outcomeEntropy -= p * math.Log2(p)
 	}
 
-	return entropy, nil
+	return itemEntropy, terrainEntropy, outcomeEntropy
 }

--- a/jj/entropy/analyze.go
+++ b/jj/entropy/analyze.go
@@ -1,0 +1,46 @@
+package entropy
+
+import (
+	"errors"
+	"math"
+	"math/big"
+)
+
+var ErrParseBlockHash error = errors.New("could not parse block number")
+
+func EntropyModN(blocks []BlockResult, N int) (float64, error) {
+	index := make(map[string]bool)
+	reductionFrequencies := make(map[int64]int)
+
+	base := new(big.Int)
+	base.SetInt64(int64(N))
+	for _, block := range blocks {
+		_, blockNumberProcessed := index[block.Number]
+		if !blockNumberProcessed {
+			index[block.Number] = true
+
+			value := new(big.Int)
+			_, ok := value.SetString(block.Hash, 0)
+			if !ok {
+				return 0, ErrParseBlockHash
+			}
+
+			reduction := value.Mod(value, base).Int64()
+
+			_, reductionExists := reductionFrequencies[reduction]
+			if reductionExists {
+				reductionFrequencies[reduction] += 1
+			} else {
+				reductionFrequencies[reduction] = 1
+			}
+		}
+	}
+
+	var entropy float64 = 0
+	for _, frequency := range reductionFrequencies {
+		p := float64(frequency) / float64(len(index))
+		entropy -= p * math.Log2(p)
+	}
+
+	return entropy, nil
+}

--- a/jj/entropy/blocks.go
+++ b/jj/entropy/blocks.go
@@ -1,0 +1,155 @@
+package entropy
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"math/big"
+	"net/http"
+)
+
+// This struct represents the result in a from the Ethereum JSON-RPC API for the `eth_getBlockByNumber` method.
+// BlockResult represents the object stored under the "result" key of the sample response documented with BlockResponse below.
+type BlockResult struct {
+	BaseFeePerGas    string   `json:"baseFeePerGas"`
+	Difficulty       string   `json:"difficulty"`
+	ExtraData        string   `json:"extraData"`
+	GasLimit         string   `json:"gasLimit"`
+	GasUsed          string   `json:"gasUsed"`
+	Hash             string   `json:"hash"`
+	L1BlockNumber    string   `json:"l1BlockNumber"`
+	LogsBloom        string   `json:"logsBloom"`
+	Miner            string   `json:"miner"`
+	MixHash          string   `json:"mixHash"`
+	Nonce            string   `json:"nonce"`
+	Number           string   `json:"number"`
+	ParentHash       string   `json:"parentHash"`
+	ReceiptsRoot     string   `json:"receiptsRoot"`
+	SendCount        string   `json:"sendCount"`
+	SendRoot         string   `json:"sendRoot"`
+	Sha3Uncles       string   `json:"sha3Uncles"`
+	Size             string   `json:"size"`
+	StateRoot        string   `json:"stateRoot"`
+	Timestamp        string   `json:"timestamp"`
+	TotalDifficulty  string   `json:"totalDifficulty"`
+	Transactions     []string `json:"transactions"`
+	TransactionsRoot string   `json:"transactionsRoot"`
+	Uncles           []string `json:"uncles"`
+}
+
+// This represents the full API response from the Ethereum JSON-RPC API for the `eth_getBlockByNumber` method.
+// A sample:
+//
+//	{
+//	  "jsonrpc": "2.0",
+//	  "result": {
+//	    "baseFeePerGas": "0x50a5ff0",
+//	    "difficulty": "0x1",
+//	    "extraData": "0x8ccde7ad600340184153fae21ff4bcdf4b671e8feff6fe1fe0d3d7cf06b6582a",
+//	    "gasLimit": "0x4000000000000",
+//	    "gasUsed": "0x1e525c",
+//	    "hash": "0x50caeaad3fc310c62608edc880b3796685804c69652bec8e822eb7ac09e3978d",
+//	    "l1BlockNumber": "0xeb875a",
+//	    "logsBloom": "0x00300000000000001000000080000800000000000080000800000000000000100000020411000000000040000600000008800000000000000008000000002000000000000000010000080008000000300000000040000000000000008800000000000000000010200000000000000000000020000000000000000030000000000000021000080000000000000000000000000109008100080000006000001000080100000000000000000000010000020001000100000000000000100000000000000002000000000000000000000000000200000008041020000004000000004000000001040000010000000010000000000000002000400000280000200000",
+//	    "miner": "0xa4b000000000000000000073657175656e636572",
+//	    "mixHash": "0x0000000000004fa90000000000eb875a000000000000000a0000000000000000",
+//	    "nonce": "0x000000000001eec6",
+//	    "number": "0x1598762",
+//	    "parentHash": "0x9cb6e1ec426087814358d95bb33600fd86cb52fd8d2c880f32a7a7477a3ac58f",
+//	    "receiptsRoot": "0xad2133328c54466c80027988ee256d817f7893fe8a4eeb754d75e90a33f1396a",
+//	    "sendCount": "0x4fa9",
+//	    "sendRoot": "0x8ccde7ad600340184153fae21ff4bcdf4b671e8feff6fe1fe0d3d7cf06b6582a",
+//	    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+//	    "size": "0xc4b",
+//	    "stateRoot": "0xa71abab49323e20d707666686fe4c246a6b66df5ecad33ecfea3a119c2dffb03",
+//	    "timestamp": "0x66616ba9",
+//	    "totalDifficulty": "0x1598763",
+//	    "transactions": [
+//	      "0x0274307a8f9a76124e4d47f4a33d66bd11748364069362938223150870de73ea",
+//	      "0x047f120188a517918c9202e34108e57282cac7c9b4aa0e683c201fa41c318709",
+//	      "0x266a9bb8c0c5c0d0aad50e06c3622a2cadc3ca89946303e2b899d09e7ca0cdeb",
+//	      "0x29df4a4250d781657916d87f9d22ca4bab0eeaa4148ea07f98e65839c8665029",
+//	      "0x7fb1b26c76e92b4694530a94cd0e42737b504ca1c988028ecfa72a8fbb4e832b",
+//	      "0x0143c88d54d1a18e738f14247d50036acb621dfa1352a4f4e3172e913d1b021f",
+//	      "0xe9ecc6f5e657816b5bbe9f8793dd682976ef4c48daf0b36acee58b227cae5c9a",
+//	      "0xa904a8576906c88034068767097a8207c1323376b5778506505582ee173d9749",
+//	      "0x23a22279e18acb856b902e86f175d42c84c30a2db065e8d23c8b7165dae34325",
+//	      "0xada84b9003f4fb52d4b7257f085a99d8279fccc27276bb1bf64167b895752feb",
+//	      "0xa10c069e787265d89cc55c2d283725483c4b1d20909d50a3efa834cb90b2e852"
+//	    ],
+//	    "transactionsRoot": "0x34bc3308bbd0a36afc7b453bdbf28d14fbfae5215c5b7b7601404cc05f593665",
+//	    "uncles": []
+//	  },
+//	  "id": 0
+//	}
+type BlockResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Result  BlockResult `json:"result"`
+	ID      int         `json:"id"`
+}
+
+func GetBlock(client *http.Client, rpc string, blockNumber *big.Int, id int) (BlockResult, error) {
+	blockNumberParameter := "latest"
+	if blockNumber != nil {
+		blockNumberParameter = "0x" + blockNumber.Text(16)
+	}
+
+	body := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "eth_getBlockByNumber",
+		"params":  []interface{}{blockNumberParameter, false},
+		"id":      id,
+	}
+
+	bodyJSON, marshalErr := json.Marshal(body)
+	if marshalErr != nil {
+		return BlockResult{}, marshalErr
+	}
+
+	request, requestErr := http.NewRequest("POST", rpc, bytes.NewBuffer(bodyJSON))
+	if requestErr != nil {
+		return BlockResult{}, requestErr
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	response, responseErr := client.Do(request)
+	if responseErr != nil {
+		return BlockResult{}, responseErr
+	}
+
+	var blockResponse BlockResponse
+	unmarshalErr := json.NewDecoder(response.Body).Decode(&blockResponse)
+	if unmarshalErr != nil {
+		return BlockResult{}, unmarshalErr
+	}
+
+	return blockResponse.Result, nil
+}
+
+func GetRandomBlocks(client *http.Client, rpc string, latestBlockNumber *big.Int, samples int) ([]BlockResult, error) {
+	if latestBlockNumber == nil {
+		latestBlock, latestBlockErr := GetBlock(client, rpc, nil, 0)
+		if latestBlockErr != nil {
+			return []BlockResult{}, latestBlockErr
+		}
+		latestBlockNumber = new(big.Int)
+		latestBlockNumber.SetString(latestBlock.Number, 0)
+	}
+
+	blocks := make([]BlockResult, samples)
+	for i := 0; i < samples; i++ {
+		blockNumber, sampleErr := rand.Int(rand.Reader, latestBlockNumber)
+		if sampleErr != nil {
+			return blocks, sampleErr
+		}
+
+		var blockErr error
+		blocks[i], blockErr = GetBlock(client, rpc, blockNumber, i)
+		if blockErr != nil {
+			return blocks, blockErr
+		}
+	}
+
+	return blocks, nil
+}


### PR DESCRIPTION
This PR introduces the `jj entropy` command which can be used to analyze block hashes as a source of entropy in the game to evaluate fairness.